### PR TITLE
feat: consistent voice channel connect status

### DIFF
--- a/import.css
+++ b/import.css
@@ -270,6 +270,11 @@ html:not(.visual-refresh).show-redesigned-icons body::before {
   /* makes the panel bigger */
 }
 
+.container_e131a9 {
+  padding: 16px 16px 16px 20px !important;
+  margin: 0 !important;
+}
+
 .avatarWrapper__37e49 {
   gap: 12px !important;
   /* increases the gap between panel pfp and name */
@@ -296,7 +301,7 @@ html:not(.visual-refresh).show-redesigned-icons body::before {
 }
 
 .sidebar_c48ade:has(.voiceButtonsContainer_e131a9) .guilds_c48ade {
-  height: calc(100% - 134px);
+  height: calc(100% - 151px);
 }
 
 a.link__2ea32,


### PR DESCRIPTION
this makes the padding on voice channel connect status more consistent so it doesn't look weird

before:
![image](https://github.com/user-attachments/assets/7d03af0e-dab2-403f-9c8e-d7d5e4767ac6)
after:
![image](https://github.com/user-attachments/assets/ddd3cf60-1b26-4830-af78-84b8072e136d)
